### PR TITLE
Add persistent volume for mise

### DIFF
--- a/src/mise/devcontainer-feature.json
+++ b/src/mise/devcontainer-feature.json
@@ -4,7 +4,19 @@
     "version": "0.1.0",
     "description": "Mise is a polyglot tool version manager. It replaces tools like asdf, nvm, pyenv, rbenv, etc.",
     "options": {},
-    "installsAfter": [
-        "ghcr.io/devcontainers/features/common-utils"
-    ]
+    "dependsOn": {
+        "ghcr.io/devcontainers/features/common-utils": {}
+    },
+    "mounts": [
+        {
+            "source": "mise-data",
+            "target": "/opt/mise",
+            "type": "volume"
+        }
+    ],
+    "containerEnv": {
+        "MISE_DATA_DIR": "/opt/mise/data",
+        "MISE_CACHE_DIR": "/opt/mise/cache",
+        "MISE_TMP_DIR": "/opt/mise/tmp"
+    }
 }

--- a/src/mise/install.sh
+++ b/src/mise/install.sh
@@ -3,7 +3,6 @@ set -e
 
 echo "Activating feature 'mise'"
 
-
 # The 'install.sh' entrypoint script is always executed as the root user.
 #
 # These following environment variables are passed in by the dev container CLI.
@@ -16,16 +15,16 @@ echo "Activating feature 'mise'"
 # echo "The effective dev container containerUser is '$_CONTAINER_USER'"
 # echo "The effective dev container containerUser's home directory is '$_CONTAINER_USER_HOME'"
 
-
 INSTALL_SCRIPT_URL="https://mise.run"
 INSTALL_PATH="/usr/local/bin"
+OPT_PATH="/opt/mise"
 
+mkdir -p $OPT_PATH
 curl $INSTALL_SCRIPT_URL | MISE_INSTALL_PATH="/usr/local/bin/mise" sh
 
 echo 'eval "$(mise activate bash)"' >> "${_REMOTE_USER_HOME}/.bashrc"
 echo 'eval "$(mise activate zsh)"' >> "${_REMOTE_USER_HOME}/.zshrc"
-mkdir -p /etc/fish/conf.d/
-echo 'mise activate fish | source' >> /etc/fish/conf.d/mise.fish
+mkdir -p /etc/fish/conf.d/ && echo 'mise activate fish | source' >> /etc/fish/conf.d/mise.fish
 
 # TODO: add shell completions
 # USAGE_VERSION="latest"  # But for mise tool spec we need string "latest"
@@ -33,3 +32,5 @@ echo 'mise activate fish | source' >> /etc/fish/conf.d/mise.fish
 # usage_binary=(mise which usage --tool="usage@${USAGE_VERSION}")
 # cp "${usage_binary}" ${INSTALL_PATH}
 # mise completion fish > /etc/fish/completions/mise.fish
+
+chown -R $_REMOTE_USER $OPT_PATH

--- a/test/mise/test.sh
+++ b/test/mise/test.sh
@@ -42,7 +42,7 @@ source dev-container-features-test-lib
 # check <LABEL> <cmd> [args...]
 check "mise is available on path" bash -c "mise version"
 
-# Not sure how to make this work in this test
+# TODO: Not sure how to make this work in this test
 # check "no mise doctor problems" bash -c "mise exec -- mise doctor | grep 'No problems found'"
 # check "no mise doctor warnings" bash -c "mise exec -- mise doctor | grep 'No warnings found'"
 


### PR DESCRIPTION
Mise will now have a persistent volume at `/opt/mise` - this should help with container rebuilds speed.