### PR TITLE
Fix mise shell completion problems

### DIFF
--- a/src/mise/install.sh
+++ b/src/mise/install.sh
@@ -16,18 +16,25 @@ echo "Activating feature 'mise'"
 # echo "The effective dev container containerUser's home directory is '$_CONTAINER_USER_HOME'"
 
 INSTALL_SCRIPT_URL="https://mise.run"
-INSTALL_PATH="/usr/local/bin"
 OPT_PATH="/opt/mise"
 
+# Download binary & put it on the path
 mkdir -p $OPT_PATH
 curl $INSTALL_SCRIPT_URL | MISE_INSTALL_PATH="/usr/local/bin/mise" sh
 
+# Global activation
 echo 'eval "$(mise activate bash)"' >> "${_REMOTE_USER_HOME}/.bashrc"
 echo 'eval "$(mise activate zsh)"' >> "${_REMOTE_USER_HOME}/.zshrc"
 mkdir -p /etc/fish/conf.d/ && echo 'mise activate fish | source' >> /etc/fish/conf.d/mise.fish
 
-mise install usage
-mkdir -p /usr/share/bash-completion/completions/ && mise completions zsh > /usr/share/bash-completion/completions/mise
+# Shell completion
+# `mise` uses `usage` in it's shell completions
+mise install usage@latest
+usage_path=$(mise where usage@latest)
+# put usage on path regardles of mise activation
+sudo ln -s "${usage_path}/bin/usage" /usr/local/bin/
+# TODO: make sure these paths work in non-Debian distros as well
+mkdir -p /usr/share/bash-completion/completions/ && mise completions bash > /usr/share/bash-completion/completions/mise
 mkdir -p /usr/share/zsh/vendor-completions/ && mise completions zsh > /usr/share/zsh/vendor-completions/_mise
 mkdir -p /etc/fish/completions/ && mise completion fish > /etc/fish/completions/mise.fish
 


### PR DESCRIPTION
There were two problems with shell compeltions introduced in #7:

1. Completions rely on `usage` and even though it was installed using `mise` it wasn't configured to be used. This PR
   links installed `usage` to `/usr/local/bin` so that it's available independently of mise config

2. Bash completion file was contained ZSH completion instead
